### PR TITLE
Fix heroku

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generate-pdf-scripts",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "scripts to generate pdfs of html pages",
   "main": "index.js",
   "scripts": {

--- a/src/generate-pdf.js
+++ b/src/generate-pdf.js
@@ -92,7 +92,7 @@ async function getUrlPdfCli() {
     .help().argv;
 
   try {
-    const browser = await puppeteer.launch();
+    const browser = await puppeteer.launch({ args: ['--no-sandbox'] });
     var pdfContents = await getUrlPdf(
       browser,
       argv.url,


### PR DESCRIPTION
This is to address our issue with PDF generation. 

PDF generation has been failing because we don't have the neccisary dependancies for puppeteer on our heroku boxes. Following [the documentation](https://developers.google.com/web/tools/puppeteer/troubleshooting#running_puppeteer_on_heroku) on how to resolve this issue on heroku, we are required to pass the arguments present in this diff to the`puppeteer.launch()` function.

[jira](https://codedotorg.atlassian.net/browse/LP-1473)

Tested by running integration tests for this package